### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,36 @@ import Tooltip from 'react-tooltip-lite';
 
 **CodePen demo**: [http://codepen.io/bsidelinger912/pen/WOdPNK](http://codepen.io/bsidelinger912/pen/WOdPNK)
 
-<br />
+#### Important note about contents
+`@wowanalyzer/react-tooltip-lite` *needs* a **single** element to attach to. This element can be either:
 
-### styling
+1. React component (`<Link>` for example, or your custom components)
+2. HTML elements like `<div>`
+
+It cannot be a `React.Fragment` because then it won't have a target to attach to. In the same sense, it can't be a plain text or text mixed with other JSX, then it needs a wrapper element. 
+
+If you wish to put a tooltip on a custom React component, you need to make sure it spreads other properties and sets `ref` property on some element, like here:
+```javascript
+class SomeComponent extends React.Component {
+  render() {
+    const { innerRef, ...others } = this.props;
+    return (
+      <div 
+        ref={innerRef} 
+        {...others}
+      >
+        Hello
+      </div>
+    );
+  }
+}
+
+<Tooltip content="Hello">
+  <SomeComponent />
+</Tooltip>
+```
+`innerRef` needs to be specifically deconstructed from `this.props` and set as a `ref` parameter on some element, same with `...others` (it contains the mouseover/toggle events for the tooltip).
+### Styling
 By default you need to style react-tooltip-lite with CSS, this allows for psuedo elements and some cool border tricks, as well as using css/sass/less variables and such to keep your colors consistent. (Note: as of version 1.2.0 you can also pass the "useDefaultStyles" prop which will allow you to use react-tooltip-lite without a stylesheet.)  
 
 Since the tooltip's arrow is created using the css border rule (https://css-tricks.com/snippets/css/css-triangle/), you'll want to specify the border-color for the arrow to set it's color. 
@@ -66,11 +93,6 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
       <td>the contents of your hover target</td>
     </tr>
     <tr>
-      <td>tagName</td>
-      <td>string</td>
-      <td>html tag used for className</td>
-    </tr>
-    <tr>
       <td>direction</td>
       <td>string</td>
       <td>the tip direction, defaults to up.   Possible values are "up", "down", "left", "right" with optional modifer for alignment of "start" and "end".    e.g. "left-start" will attempt tooltip on left and align it with the start of the target.   If alignment modifier is not specified the default behavior is to align "middle".</td>
@@ -78,7 +100,7 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
     <tr>
       <td>className</td>
       <td>string</td>
-      <td>css class added to the rendered wrapper</td>
+      <td>css class added to the rendered tooltip</td>
     </tr>
     <tr>
       <td>background</td>
@@ -94,11 +116,6 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
       <td>padding</td>
       <td>string</td>
       <td>padding amount for the tooltip contents (defaults to '10px')</td>
-    </tr>
-    <tr>
-      <td>styles</td>
-      <td>object</td>
-      <td>style overrides for the target wrapper</td>
     </tr>
     <tr>
       <td>eventOn</td>
@@ -139,7 +156,7 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
     <tr>
       <td>hoverDelay</td>
       <td>number</td>
-      <td>the number of milliseconds to determine hover intent, defaults to 200</td>
+      <td>the number of milliseconds to determine hover intent, defaults to 0</td>
     </tr>
     <tr>
       <td>arrow</td>
@@ -177,10 +194,10 @@ You can pass in props to define tip direction, styling, etc.  Content is the onl
       </div>
   )}
   direction="right"
-  tagName="span"
-  className="target"
 >
-    Target content for big html tip
+    <span>
+        Target content for big html tip
+    </span>
 </Tooltip>
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ class SomeComponent extends React.Component {
 </Tooltip>
 ```
 `innerRef` needs to be specifically deconstructed from `this.props` and set as a `ref` parameter on some element, same with `...others` (it contains the mouseover/toggle events for the tooltip).
+
+Alternatively, you can wrap the component in `<div>` or `<span>` element.
 ### Styling
 By default you need to style react-tooltip-lite with CSS, this allows for psuedo elements and some cool border tricks, as well as using css/sass/less variables and such to keep your colors consistent. (Note: as of version 1.2.0 you can also pass the "useDefaultStyles" prop which will allow you to use react-tooltip-lite without a stylesheet.)  
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wowanalyzer/react-tooltip-lite",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "React tooltip, focused on simplicity and performance",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bsidelinger912/react-tooltip-lite.git"
+    "url": "git+https://github.com/WoWAnalyzer/react-tooltip-lite.git"
   },
   "keywords": [
     "React"
@@ -25,9 +25,9 @@
   "author": "Ben Sidelinger",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/bsidelinger912/react-tooltip-lite/issues"
+    "url": "https://github.com/WoWAnalyzer/react-tooltip-lite/issues"
   },
-  "homepage": "https://github.com/bsidelinger912/react-tooltip-lite#readme",
+  "homepage": "https://github.com/WoWAnalyzer/react-tooltip-lite#readme",
   "dependencies": {
     "prop-types": "^15.5.8",
     "react-minimalist-portal": "2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wowanalyzer/react-tooltip-lite",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "description": "React tooltip, focused on simplicity and performance",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Tooltip.jsx
+++ b/src/Tooltip.jsx
@@ -194,6 +194,8 @@ class Tooltip extends React.PureComponent {
             arrowSize={arrowSize}
             distance={distance}
             target={this.target.current}
+            startHover={this.startHover}
+            endHover={this.endHover}
           />
         )}
       </React.Fragment>

--- a/src/TooltipBubble.jsx
+++ b/src/TooltipBubble.jsx
@@ -30,6 +30,8 @@ class TooltipBubble extends React.PureComponent {
     arrowSize: PropTypes.number,
     distance: PropTypes.number,
     target: PropTypes.object,
+    startHover: PropTypes.func,
+    endHover: PropTypes.func,
   };
   static defaultProps = {
     direction: 'up',
@@ -73,6 +75,8 @@ class TooltipBubble extends React.PureComponent {
       arrowSize,
       distance,
       target,
+      startHover,
+      endHover
     } = this.props;
 
     const currentPositions = positions(direction, this.tip.current, target, {
@@ -107,8 +111,8 @@ class TooltipBubble extends React.PureComponent {
     };
 
     if (!eventToggle && useHover && tipContentHover) {
-      portalProps.onMouseOver = this.startHover;
-      portalProps.onMouseOut = this.endHover;
+      portalProps.onMouseOver = startHover;
+      portalProps.onMouseOut = endHover;
       portalProps.onTouchStart = stopProp;
     }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,6 @@ declare module 'react-tooltip-lite' {
   import * as React from 'react';
 
   export interface TooltipProps {
-    tagName?: string;
     direction?: string;
     className?: string;
     content: React.ReactNode;
@@ -11,7 +10,6 @@ declare module 'react-tooltip-lite' {
     color?: string;
     padding?: string;
     distance?: number;
-    styles?: object;
     eventOff?: string;
     eventOn?: string;
     eventToggle?: string;
@@ -24,7 +22,7 @@ declare module 'react-tooltip-lite' {
     arrowSize?: number;
   }
 
-  export default class Tooltip extends React.Component<TooltipProps> {
+  export default class Tooltip extends React.PureComponent<TooltipProps> {
   }
 
 }


### PR DESCRIPTION
Removed old props from `index.d.ts`, updated *some* documentation in `README.md` - there's still a lot of outdated info, mainly Getting Started, CodePen demo, examples. Also bumped the major version since there were breaking changes.

EDIT: Also fixed the `tipContentHover` property as it didn't allow hovering over the tooltip