### PR TITLE
Replace react-minimalist-portal

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,10 @@
   },
   "homepage": "https://github.com/WoWAnalyzer/react-tooltip-lite#readme",
   "dependencies": {
-    "prop-types": "^15.5.8",
-    "react-minimalist-portal": "2.3.1"
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
-    "react": "^15.5.4 || ^16.0.0"
+    "react": "^17.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -52,9 +51,9 @@
     "eslint-plugin-react": "^6.7.1",
     "expect": "^1.20.2",
     "mocha": "^2.5.3",
-    "react": "^16.2.0",
+    "react": "^17.0.2",
     "react-addons-test-utils": "^15.2.1",
-    "react-dom": "^16.2.0",
+    "react-dom": "^17.0.2",
     "react-hot-loader": "^1.3.1",
     "webpack": "^1.13.3",
     "webpack-dev-server": "^1.16.2"

--- a/src/Portal.jsx
+++ b/src/Portal.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+
+export default function Portal({ children }) {
+  const elRef = useRef(null);
+  if (!elRef.current) {
+    elRef.current = document.createElement('div');
+  }
+
+  useEffect(() => {
+    const portalRoot = document.getElementById('portal-root');
+    if (!portalRoot) {
+      return;
+    }
+
+    portalRoot.appendChild(elRef.current);
+    return () => {
+      portalRoot.removeChild(elRef.current);
+    };
+  }, []);
+
+  return ReactDOM.createPortal(children, elRef.current);
+}

--- a/src/TooltipBubble.jsx
+++ b/src/TooltipBubble.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Portal from 'react-minimalist-portal';
+import Portal from './Portal';
 import positions from './position';
 
 // default colors
@@ -76,7 +76,7 @@ class TooltipBubble extends React.PureComponent {
       distance,
       target,
       startHover,
-      endHover
+      endHover,
     } = this.props;
 
     const currentPositions = positions(direction, this.tip.current, target, {

--- a/src/getDirection.js
+++ b/src/getDirection.js
@@ -94,7 +94,7 @@ export default function getDirection(currentDirection, tip, target, props, bodyP
         if (hasSpaceAbove) {
           return 'up';
 
-          // if there's not space above or below, check if there would be space left or right
+          // if there's no space above or below, check if there would be space left or right
         } else if (checkLeftRightWidthSufficient(tip, target, arrowSpacing, bodyPadding)) {
           return getDirection('right', tip, target, arrowSpacing, bodyPadding, arrowStyles, true);
         }

--- a/src/position.js
+++ b/src/position.js
@@ -13,11 +13,11 @@ const noArrowDistance = 3;
  * cross browser scroll positions
  */
 function getScrollTop() {
-  return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+  return window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
 }
 
 export function getScrollLeft() {
-  return window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
+  return window.scrollX || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
 }
 
 /**


### PR DESCRIPTION
**Please tag as v3.1.3 after merging.**

Noticed the following warning in the console on the homepage of WoWA. This only occours on development environments.

![image](https://github.com/user-attachments/assets/0d144a21-2ce6-4a89-9257-f9b0e0abc7c5)

These changes replace the `react-minimalist-portal` package with a minimalist portal of its own.
Further change requirements will be made in the WoWA repo in a new MR.


Still works with the change;
![image](https://github.com/user-attachments/assets/f3d182ed-17e0-49a6-921b-e437fb7c4ff5)

